### PR TITLE
fix: resolve high severity Dependabot vulnerability (undici)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   },
   "pnpm": {
     "overrides": {
-      "minimatch": ">=10.2.3"
+      "minimatch": ">=10.2.3",
+      "undici": ">=7.24.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   minimatch: '>=10.2.3'
+  undici: '>=7.24.0'
 
 importers:
 
@@ -1810,9 +1811,9 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.20.0:
-    resolution: {integrity: sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==}
-    engines: {node: '>=20.18.1'}
+  undici@8.2.0:
+    resolution: {integrity: sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==}
+    engines: {node: '>=22.19.0'}
 
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
@@ -3212,7 +3213,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 7.20.0
+      undici: 8.2.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -3580,7 +3581,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.20.0: {}
+  undici@8.2.0: {}
 
   unplugin@2.3.11:
     dependencies:


### PR DESCRIPTION
## Summary

- `undici` >=7.24.0: malicious WebSocket 64-bit length がパーサーをオーバーフローさせクラッシュする DoS 脆弱性 (GHSA)

`pnpm.overrides` で間接依存を 7.24.0 以上に強制アップグレード（7.20.0 → 8.2.0）。

## Test plan

- [ ] `pnpm install` がエラーなく通ること
- [ ] `pnpm run dev` / `pnpm run test` が正常動作すること
- [ ] GitHub Dependabot アラート #164 が closed になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)