### PR TITLE
fix: update fix-dependabot workflow (Node.js 24対応 + 各種改善)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,70 @@
+# Workflows
+
+## fix-dependabot.yml — Dependabot 脆弱性の自動修正
+
+### 用途
+
+Dependabot が検出したセキュリティアラートに対して、パッケージのバージョン制約を自動で引き上げ、修正 PR を作成するワークフロー。
+
+Dependabot 標準の自動 PR はパッケージマネージャーによっては動作しない場合がある。このワークフローは `package.json` の `overrides` / `resolutions`、または Python のパッケージファイルに直接バージョン制約を書き込むことで、間接依存を含む脆弱パッケージを強制的にアップグレードする暫定対応を行う。
+
+### 認証方法
+
+追加の Secrets や GitHub App は不要。ランナーに自動付与される **`GITHUB_TOKEN`** のみで完結する。
+
+必要な権限は以下の 3 つ。いずれもワークフローファイル内で明示的に宣言している。
+
+| 権限 | 用途 |
+|---|---|
+| `security-events: read` | Dependabot アラートの取得 |
+| `contents: write` | 修正ブランチの作成・push |
+| `pull-requests: write` | 修正 PR の作成 |
+
+### 動作フロー
+
+```
+1. open 状態の Dependabot アラートを全件取得（severity でフィルタ）
+         ↓
+2. パッケージマネージャーを自動判定
+         ↓
+3. 既存の修正 PR があればスキップ（重複防止）
+         ↓
+4. 修正ブランチを作成（fix/dependabot-<run_id>）
+         ↓
+5. パッケージファイルにバージョン制約を書き込む
+         ↓
+6. ロックファイルを再生成（install 実行）
+         ↓
+7. 変更をコミット・push して PR を作成
+```
+
+### 対応パッケージマネージャー
+
+| マネージャー | 修正方法 |
+|---|---|
+| pnpm | `pnpm.overrides` に `^FIXED` を追記 |
+| yarn | `resolutions` に `^FIXED` を追記 |
+| npm | `overrides` に `^FIXED` を追記 |
+| pip | `requirements.txt` に `>=FIXED` を追記 |
+| poetry | `pyproject.toml` の `[tool.poetry.dependencies]` に `>=FIXED,<NEXT_MAJOR` を追記 |
+| pipenv | `Pipfile` の `[packages]` に `>=FIXED,<NEXT_MAJOR` を追記 |
+
+リポジトリ内で最初に見つかったマネージャー 1 種のみを処理する（複数マネージャー混在リポジトリは非対応）。
+
+### トリガー
+
+| トリガー | 条件 |
+|---|---|
+| `schedule` | 毎週月曜 09:00 JST に自動実行 |
+| `workflow_dispatch` | Actions タブから手動実行（severity をカスタマイズ可能） |
+
+### 手動実行時のパラメータ
+
+| パラメータ | デフォルト | 説明 |
+|---|---|---|
+| `severity` | `critical high medium` | 対象 severity をスペース区切りで指定。指定可能な値: `critical` `high` `medium` `low` |
+
+### 注意事項
+
+- このワークフローの修正は**暫定対応**。`overrides` / `resolutions` は間接依存を強制バージョンアップするもので、直接依存のアップグレードで解消できる場合は overrides を削除することを推奨
+- `GITHUB_TOKEN` で作成した PR は他の GitHub Actions ワークフローのトリガーにならない（GitHub の仕様）。CI が必要な場合は手動で再実行するか、GitHub App を利用する

--- a/.github/workflows/fix-dependabot.yml
+++ b/.github/workflows/fix-dependabot.yml
@@ -9,8 +9,13 @@ on:
       severity:
         description: '対象 severity（スペース区切りで複数指定可）'
         required: false
-        default: 'critical high'
+        default: 'critical high medium'
         type: string
+
+# 同一グループの実行が重なった場合は先行ジョブが完了するまでキューに積む
+concurrency:
+  group: fix-dependabot
+  cancel-in-progress: false
 
 # GitHub App は使用しない。GITHUB_TOKEN のみで完結する
 permissions:
@@ -21,24 +26,25 @@ permissions:
 jobs:
   fix:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       SEVERITY: ${{ inputs.severity || 'critical high' }}
     steps:
       # JS 依存の overrides 適用・インストールに必要な Node.js 環境をセットアップ
       - name: Node.js をセットアップ
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '20'
 
       # pnpm を使うリポジトリ向けにセットアップ（yarn/npm はランナーに標準搭載）
       - name: pnpm をセットアップ
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
         with:
-          version: latest
+          version: '9'
 
       # Python 依存のインストールに必要な環境をセットアップ
       - name: Python をセットアップ
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.x'
 
@@ -48,23 +54,24 @@ jobs:
 
       # GITHUB_TOKEN で認証してチェックアウトし、git push が使える認証情報を設定する
       - name: リポジトリをチェックアウト
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ github.token }}
 
-      # 自リポジトリの open Dependabot アラートを取得し /tmp/alerts.json に保存する
-      #
+      # 自リポジトリの open Dependabot アラートを全件取得する（100 件超でも漏れなし）
       - name: open Dependabot アラートを取得
         id: fetch-alerts
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
+          set -o pipefail
           SEVERITY_FILTER=$(echo "$SEVERITY" | tr ' ' '\n' | jq -R . | jq -sc .)
 
-          if ! gh api \
-            "repos/${{ github.repository }}/dependabot/alerts?state=open&per_page=100" \
-            > /tmp/alerts-raw.json 2>/dev/null; then
-            echo "[]" > /tmp/alerts-raw.json
+          if ! gh api --paginate \
+            "repos/${REPO}/dependabot/alerts?state=open&per_page=100" \
+            | jq -s 'add // []' > "${RUNNER_TEMP}/alerts-raw.json" 2>/dev/null; then
+            echo "[]" > "${RUNNER_TEMP}/alerts-raw.json"
           fi
 
           # ecosystem でフィルタして該当する first_patched_version を取得する
@@ -91,11 +98,11 @@ jobs:
                 summary: $alert.security_advisory.summary
               }
             ]
-          ' /tmp/alerts-raw.json > /tmp/alerts.json
+          ' "${RUNNER_TEMP}/alerts-raw.json" > "${RUNNER_TEMP}/alerts.json"
 
-          ALERT_COUNT=$(jq length /tmp/alerts.json)
+          ALERT_COUNT=$(jq length "${RUNNER_TEMP}/alerts.json")
           echo "対象アラート: ${ALERT_COUNT} 件"
-          cat /tmp/alerts.json
+          cat "${RUNNER_TEMP}/alerts.json"
           echo "alert_count=$ALERT_COUNT" >> "$GITHUB_OUTPUT"
 
       # ロックファイル・パッケージファイルの種類でパッケージマネージャーを判定し
@@ -140,10 +147,29 @@ jobs:
             echo "::warning::対応するパッケージマネージャーが見つかりません。スキップします。"
           fi
 
+      # fix/dependabot- プレフィックスの open PR が既にある場合はスキップして重複を防ぐ
+      - name: 既存の修正 PR を確認
+        id: check-pr
+        if: steps.pkg-manager.outputs.supported == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXISTING=$(gh pr list \
+            --state open \
+            --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("fix/dependabot-"))] | .[0].number // empty' \
+            2>/dev/null || true)
+          if [ -n "$EXISTING" ]; then
+            echo "::warning::既存の修正 PR #${EXISTING} が open のため、このランはスキップします。"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # ブランチ名に github.run_id を使うことでレースコンディションを回避する
       # （並列で複数リポジトリに dispatch されても run_id は各実行で一意になる）
       - name: 修正ブランチを作成
-        if: steps.pkg-manager.outputs.supported == 'true'
+        if: steps.pkg-manager.outputs.supported == 'true' && steps.check-pr.outputs.skip == 'false'
         run: |
           BRANCH="fix/dependabot-${{ github.run_id }}"
           git checkout -b "$BRANCH"
@@ -154,12 +180,15 @@ jobs:
       # バージョン制約の方針:
       # - JS (pnpm/yarn/npm overrides): ^FIXED を使用
       #   >= だと次のメジャーバージョンまで許容してしまうため、semver の ^ で上限を設ける
-      # - Python (pip/poetry/pipenv): >=FIXED を維持
-      #   PEP 440 は semver ではなく ^ 記号が無効なため >= を使用する
+      # - Python (pip): >=FIXED を使用（PEP 440 は ^ 記号が無効）
+      # - Python (poetry/pipenv): >=FIXED,<NEXT_MAJOR を使用（次期メジャーを許容しない）
+      #
+      # 注意: このワークフローは最初に見つかったパッケージマネージャー 1 種のみを処理する。
+      # npm + pip が混在するリポジトリでは、最初に検出されたマネージャーの依存のみ修正される。
       - name: パッケージファイルにバージョン制約を適用
-        if: steps.pkg-manager.outputs.supported == 'true'
+        if: steps.pkg-manager.outputs.supported == 'true' && steps.check-pr.outputs.skip == 'false'
         run: |
-          jq -c '.[]' /tmp/alerts.json | while read -r alert; do
+          jq -c '.[]' "${RUNNER_TEMP}/alerts.json" | while read -r alert; do
             PKG=$(echo "$alert" | jq -r '.pkg')
             FIXED=$(echo "$alert" | jq -r '.fixed')
 
@@ -167,39 +196,47 @@ jobs:
               # pnpm.overrides に ^FIXED でピンする（semver: メジャーバージョン内に限定）
               jq --arg pkg "$PKG" --arg ver "^$FIXED" \
                 '.pnpm.overrides[$pkg] = $ver' \
-                package.json > /tmp/pkg.json && mv /tmp/pkg.json package.json
+                package.json > "${RUNNER_TEMP}/pkg.json" && mv "${RUNNER_TEMP}/pkg.json" package.json
 
             elif [ "$PKG_MANAGER" = "yarn" ]; then
               jq --arg pkg "$PKG" --arg ver "^$FIXED" \
                 '.resolutions[$pkg] = $ver' \
-                package.json > /tmp/pkg.json && mv /tmp/pkg.json package.json
+                package.json > "${RUNNER_TEMP}/pkg.json" && mv "${RUNNER_TEMP}/pkg.json" package.json
 
             elif [ "$PKG_MANAGER" = "npm" ]; then
               jq --arg pkg "$PKG" --arg ver "^$FIXED" \
                 '.overrides[$pkg] = $ver' \
-                package.json > /tmp/pkg.json && mv /tmp/pkg.json package.json
+                package.json > "${RUNNER_TEMP}/pkg.json" && mv "${RUNNER_TEMP}/pkg.json" package.json
 
             elif [ "$PKG_MANAGER" = "pip" ]; then
               # ハイフン・アンダースコアを同一視してから既存エントリを削除し追記
               PKG_PATTERN=$(echo "$PKG" | sed 's/[-_]/[-_]/g')
-              grep -iv "^${PKG_PATTERN}" requirements.txt > /tmp/req.txt || true
-              echo "${PKG}>=${FIXED}" >> /tmp/req.txt
-              mv /tmp/req.txt requirements.txt
+              grep -ivE "^${PKG_PATTERN}([>=<!;\[]|$)" requirements.txt > "${RUNNER_TEMP}/req.txt" || true
+              echo "${PKG}>=${FIXED}" >> "${RUNNER_TEMP}/req.txt"
+              mv "${RUNNER_TEMP}/req.txt" requirements.txt
 
-            elif [ "$PKG_MANAGER" = "poetry" ]; then
-              PKG_ESC=$(printf '%s' "$PKG" | sed 's/[][\.*^$()+?{|]/\\&/g')
-              if grep -qiE "^${PKG_ESC}[[:space:]]*=" pyproject.toml; then
-                sed -i "s/^${PKG_ESC}[[:space:]]*=.*/${PKG} = '>=${FIXED}'/" pyproject.toml
+            elif [ "$PKG_MANAGER" = "poetry" ] || [ "$PKG_MANAGER" = "pipenv" ]; then
+              # grep は -i（ケース無視）で検索、sed も I フラグで統一して不整合を防ぐ
+              # sed 区切り文字を | にし、FIXED/PKG の | & \ をエスケープしてコマンド破綻を防ぐ
+              if [ "$PKG_MANAGER" = "poetry" ]; then
+                TARGET_FILE="pyproject.toml"
+                SECTION='\[tool\.poetry\.dependencies\]'
               else
-                sed -i "/^\[tool\.poetry\.dependencies\]/a ${PKG} = '>=${FIXED}'" pyproject.toml
+                TARGET_FILE="Pipfile"
+                SECTION='\[packages\]'
               fi
-
-            elif [ "$PKG_MANAGER" = "pipenv" ]; then
               PKG_ESC=$(printf '%s' "$PKG" | sed 's/[][\.*^$()+?{|]/\\&/g')
-              if grep -qiE "^${PKG_ESC}[[:space:]]*=" Pipfile; then
-                sed -i "s/^${PKG_ESC}[[:space:]]*=.*/${PKG} = '>=${FIXED}'/" Pipfile
+              PKG_SED=$(printf '%s' "$PKG" | sed 's/[|&\]/\\&/g')
+              # PEP 440 エポック（例: 1!2.0.0）を除去してからメジャー番号を取得する
+              VERSION_ONLY=$(echo "$FIXED" | sed 's/^[0-9]*!//')
+              FIXED_SED=$(printf '%s' "$VERSION_ONLY" | sed 's/[|&\]/\\&/g')
+              NEXT_MAJOR=$(( $(echo "$VERSION_ONLY" | cut -d. -f1) + 1 ))
+              VERSION_SPEC="'>=${FIXED_SED},<${NEXT_MAJOR}.0.0'"
+              if grep -qiE "^${PKG_ESC}[[:space:]]*=" "$TARGET_FILE"; then
+                # -i のみ（ERE 不要）。キャプチャグループを使わず PKG_SED で直接置換する
+                sed -i "s|^${PKG_ESC}[[:space:]]*=.*|${PKG_SED} = ${VERSION_SPEC}|I" "$TARGET_FILE"
               else
-                sed -i "/^\[packages\]/a ${PKG} = '>=${FIXED}'" Pipfile
+                sed -i "/^${SECTION}/a ${PKG_SED} = ${VERSION_SPEC}" "$TARGET_FILE"
               fi
             fi
           done
@@ -208,7 +245,7 @@ jobs:
       # poetry でエラーが発生した場合（Python version conflict 等）はステップをそのまま fail させる
       # エラーメッセージのパースは行わず、ワークフロー利用者に手動対応を促す
       - name: 依存関係をインストール
-        if: steps.pkg-manager.outputs.supported == 'true'
+        if: steps.pkg-manager.outputs.supported == 'true' && steps.check-pr.outputs.skip == 'false'
         run: |
           case "$PKG_MANAGER" in
             pnpm)   pnpm install --no-frozen-lockfile ;;
@@ -223,7 +260,7 @@ jobs:
       # git diff --stat は git add 前だと untracked file（新規ロックファイル等）を検出できない
       - name: 変更差分を確認
         id: changes
-        if: steps.pkg-manager.outputs.supported == 'true'
+        if: steps.pkg-manager.outputs.supported == 'true' && steps.check-pr.outputs.skip == 'false'
         run: |
           DIFF=$(git status --porcelain)
           if [ -z "$DIFF" ]; then
@@ -240,15 +277,19 @@ jobs:
           git config user.name "dependabot-auto-fix[bot]"
           git config user.email "dependabot-auto-fix[bot]@users.noreply.github.com"
 
+          TOTAL=$(jq length "${RUNNER_TEMP}/alerts.json")
           PKG_LIST=$(jq -r '.[] | "- \(.pkg) >=\(.fixed) (\(.severity)): \(.summary[:60])"' \
-            /tmp/alerts.json | head -20)
+            "${RUNNER_TEMP}/alerts.json" | head -20)
 
-          printf 'fix: resolve Dependabot vulnerabilities via package overrides\n\n%s\n\n🤖 Auto-generated by dependabot-auto-fix GitHub Actions\n' \
-            "$PKG_LIST" > /tmp/commit-msg.txt
+          {
+            printf 'fix: resolve Dependabot vulnerabilities via package overrides\n\n%s\n' "$PKG_LIST"
+            [ "$TOTAL" -gt 20 ] && printf '(他 %d 件省略)\n' "$((TOTAL - 20))"
+            printf '\n🤖 Auto-generated by dependabot-auto-fix GitHub Actions\n'
+          } > "${RUNNER_TEMP}/commit-msg.txt"
 
           git add "$PKG_FILE"
           [ -n "${LOCKFILE:-}" ] && [ -f "$LOCKFILE" ] && git add "$LOCKFILE" || true
-          git commit -F /tmp/commit-msg.txt
+          git commit -F "${RUNNER_TEMP}/commit-msg.txt"
 
       # actions/checkout が GITHUB_TOKEN で認証設定済みのため remote URL の書き換えは不要
       - name: ブランチをプッシュ
@@ -260,13 +301,15 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASE_BRANCH: ${{ github.ref_name }}
         run: |
           PKG_TABLE=$(jq -r '
             ["| パッケージ | severity | 修正バージョン | 概要 |",
              "|-----------|---------|--------------|------|"]
             + [.[] | "| \(.pkg) | \(.severity) | >=\(.fixed) | \(.summary[:50]) |"]
             | .[]
-          ' /tmp/alerts.json)
+          ' "${RUNNER_TEMP}/alerts.json")
 
           {
             echo "## 概要"
@@ -294,11 +337,11 @@ jobs:
             echo "- [ ] ビルド・テストが正常動作すること"
             echo "- [ ] マージ後に Dependabot アラートが closed になること"
             echo ""
-            echo "🤖 Auto-generated by [dependabot-auto-fix](https://github.com/${{ github.repository }})"
-          } > /tmp/pr-body.txt
+            echo "🤖 Auto-generated by [dependabot-auto-fix](https://github.com/${REPO})"
+          } > "${RUNNER_TEMP}/pr-body.txt"
 
           gh pr create \
             --title "fix: resolve Dependabot vulnerabilities ($(date +%Y-%m-%d))" \
-            --base "${{ github.ref_name }}" \
+            --base "$BASE_BRANCH" \
             --head "$BRANCH" \
-            --body-file /tmp/pr-body.txt
+            --body-file "${RUNNER_TEMP}/pr-body.txt"


### PR DESCRIPTION
## 概要

#25 でマージした `fix-dependabot.yml` に対して、Node.js 20 deprecation 警告の解消とコードレビューで指摘された問題を修正する。

## 変更内容

### Node.js 24 対応（6月2日強制移行前に対応が必要）

| アクション | 旧 | 新 |
|---|---|---|
| `actions/checkout` | v4 | v6.0.2 |
| `actions/setup-node` | v4 | v6.4.0 |
| `actions/setup-python` | v5 | v6.2.0 |
| `pnpm/action-setup` | v4 | v6.0.8 |

全アクションをコミット SHA でピン留め済み（サプライチェーン対策）。

### 機能・安全性改善

- `concurrency` 制御追加（重複実行・重複 PR を防止）
- `timeout-minutes: 30` 追加（`poetry lock` ハング対策）
- `--paginate` でアラート全件取得（100件超の漏れを修正）
- 重複 PR 検出ステップ追加
- 一時ファイルを `$RUNNER_TEMP` に統一
- `pipefail` を fetch-alerts ステップに追加
- `sed` の区切り文字・エスケープ修正（poetry/pipenv で `/` 等を含むバージョン文字列でも安全）
- Python バージョン上限追加（`>=FIXED,<NEXT_MAJOR`）
- PEP 440 エポック形式（`1!2.0.0`）のバージョン処理に対応
- デフォルト severity に `medium` を追加

## テストプラン

- [ ] Actions タブから `workflow_dispatch` で手動実行して Node.js 20 警告が消えること
- [ ] severity に `medium` を含めた実行が正常動作すること
- [ ] Dependabot アラートがある場合に修正 PR が作成されること